### PR TITLE
Fall back to OpenGL if Direct3D isn't available

### DIFF
--- a/Exapt.Wrappers/GameLogic.cs
+++ b/Exapt.Wrappers/GameLogic.cs
@@ -33,4 +33,9 @@ public class GameLogic : NonStaticWrapper<GameLogic>
     {
         _ = Call("#=qrnUck7W$Xr7MBLj7W0QtK28NCH7Qgj1N5e$igVDhSzo=");
     }
+
+    public object CreateWindow(string title, int width, int height, int display)
+    {
+        return Call("#=qwkf$ypjdDAxMy$27u$fZSQ==", title, width, height, display);
+    }
 }

--- a/Exapt.Wrappers/GameLogic.cs
+++ b/Exapt.Wrappers/GameLogic.cs
@@ -34,8 +34,8 @@ public class GameLogic : NonStaticWrapper<GameLogic>
         _ = Call("#=qrnUck7W$Xr7MBLj7W0QtK28NCH7Qgj1N5e$igVDhSzo=");
     }
 
-    public object CreateWindow(string title, int width, int height, int display)
+    public void CreateWindow(string title, int width, int height, int display)
     {
-        return Call("#=qwkf$ypjdDAxMy$27u$fZSQ==", title, width, height, display);
+        _ = Call("#=qwkf$ypjdDAxMy$27u$fZSQ==", title, width, height, display);
     }
 }

--- a/Exapt/Program.cs
+++ b/Exapt/Program.cs
@@ -83,8 +83,19 @@ public static class Program
         Wrappers.Globals.SetRandom(new Wrappers.Random(1));
         Wrappers.Strings.Initialize();
         Wrappers.Puzzles.Initialize();
-        Wrappers.Renderer.Initialize(Wrappers.RendererType.Direct3D, false);
         Wrappers.GameLogic.Instance = new Wrappers.GameLogic();
+        try
+        {
+            Wrappers.Renderer.Initialize(Wrappers.RendererType.Direct3D, false);
+        }
+        catch (DllNotFoundException)
+        {
+            // loading D3D failed, try OpenGL instead
+            Wrappers.Renderer.Initialize(Wrappers.RendererType.OpenGl, false);
+            // note, this window won't actually be displayed, as the HIDDEN flag is
+            // passed to SDL_WindowCreate by default
+            Wrappers.GameLogic.Instance.CreateWindow("exapt", 640, 480, 0);
+        }
         Wrappers.GameLogic.Instance.InitializeFontsA(() => { });
         Wrappers.GameLogic.Instance.InitializeFontsB();
     }


### PR DESCRIPTION
As I suspected, this needed just a bit more setup: the calls to `SDL_GL_GetProcAddress()` were returning null since OpenGL hadn't been initialized, which is done during the call to CreateWindow().